### PR TITLE
Make actions int consts

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -14,6 +14,19 @@ const (
 	closeMethod = "Close"
 )
 
+type action uint8
+
+const (
+	actionUnhandled action = iota
+	actionHandled
+	actionReturned
+	actionPassed
+	actionClosed
+	actionUnvaluedCall
+	actionUnvaluedDefer
+	actionNoOp
+)
+
 var (
 	sqlPackages = []string{
 		"database/sql",
@@ -168,16 +181,16 @@ func checkClosed(refs *[]ssa.Instruction, targetTypes []*types.Pointer) bool {
 
 		action := getAction(ref, targetTypes)
 		switch action {
-		case "closed":
+		case actionClosed:
 			return true
-		case "passed":
+		case actionPassed:
 			// Passed and not used after
 			if numInstrs == idx+1 {
 				return true
 			}
-		case "returned":
+		case actionReturned:
 			return true
-		case "handled":
+		case actionHandled:
 			return true
 		default:
 			// log.Printf(action)
@@ -187,20 +200,20 @@ func checkClosed(refs *[]ssa.Instruction, targetTypes []*types.Pointer) bool {
 	return false
 }
 
-func getAction(instr ssa.Instruction, targetTypes []*types.Pointer) string {
+func getAction(instr ssa.Instruction, targetTypes []*types.Pointer) action {
 	switch instr := instr.(type) {
 	case *ssa.Defer:
 		if instr.Call.Value == nil {
-			return "unvalued defer"
+			return actionUnvaluedDefer
 		}
 
 		name := instr.Call.Value.Name()
 		if name == closeMethod {
-			return "closed"
+			return actionClosed
 		}
 	case *ssa.Call:
 		if instr.Call.Value == nil {
-			return "unvalued call"
+			return actionUnvaluedCall
 		}
 
 		isTarget := false
@@ -211,19 +224,19 @@ func getAction(instr ssa.Instruction, targetTypes []*types.Pointer) string {
 
 		name := instr.Call.Value.Name()
 		if isTarget && name == closeMethod {
-			return "closed"
+			return actionClosed
 		}
 
 		if !isTarget {
-			return "passed"
+			return actionPassed
 		}
 	case *ssa.Phi:
-		return "passed"
+		return actionPassed
 	case *ssa.MakeInterface:
-		return "passed"
+		return actionPassed
 	case *ssa.Store:
 		if len(*instr.Addr.Referrers()) == 0 {
-			return "noop"
+			return actionNoOp
 		}
 
 		for _, aRef := range *instr.Addr.Referrers() {
@@ -231,7 +244,7 @@ func getAction(instr ssa.Instruction, targetTypes []*types.Pointer) string {
 				f := c.Fn.(*ssa.Function)
 				for _, b := range f.Blocks {
 					if checkClosed(&b.Instrs, targetTypes) {
-						return "handled"
+						return actionHandled
 					}
 				}
 			}
@@ -241,21 +254,21 @@ func getAction(instr ssa.Instruction, targetTypes []*types.Pointer) string {
 		for _, targetType := range targetTypes {
 			if types.Identical(instrType, targetType) {
 				if checkClosed(instr.Referrers(), targetTypes) {
-					return "handled"
+					return actionHandled
 				}
 			}
 		}
 	case *ssa.FieldAddr:
 		if checkClosed(instr.Referrers(), targetTypes) {
-			return "handled"
+			return actionHandled
 		}
 	case *ssa.Return:
-		return "returned"
+		return actionReturned
 	default:
 		// log.Printf("%s", instr)
 	}
 
-	return "unhandled"
+	return actionUnhandled
 }
 
 func checkDeferred(pass *analysis.Pass, instrs *[]ssa.Instruction, targetTypes []*types.Pointer, inDefer bool) {


### PR DESCRIPTION
It should be a lot more efficient to pass the actions as uint8 constants instead of a string, since comparison is a lot cheaper and the return type also smaller.