### PR TITLE
Don't alert when the row/stmt is stored in a struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,22 @@
+BIN := bin
+
 PHONY: build install test
 
-build:
-	go build
+$(BIN):
+	mkdir -p $@
+
+build: $(BIN)
+	go build -o $(BIN)/sqlclosecheck .
 
 install:
 	go install
 
-test: build install
+test: build
 	go test ./...
 	# Due to an issue with importing in a anaylsistest's test data some hoop jumping is required
 	# I call twice to avoid collecting package downloads in output
-	-go vet -vettool=${GOPATH}/bin/sqlclosecheck ./testdata/sqlx_examples
-	-go vet -vettool=${GOPATH}/bin/sqlclosecheck ./testdata/sqlx_examples 2> sqlx_examples_results.txt
+	-go vet -vettool=$(BIN)/sqlclosecheck ./testdata/sqlx_examples
+	-go vet -vettool=$(BIN)/sqlclosecheck ./testdata/sqlx_examples 2> sqlx_examples_results.txt
 	diff -a sqlx_examples_results.txt ./testdata/sqlx_examples/expected_results.txt
 
 lint:

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -241,6 +241,12 @@ func getAction(instr ssa.Instruction, targetTypes []*types.Pointer) action {
 	case *ssa.MakeInterface:
 		return actionPassed
 	case *ssa.Store:
+		// A Row/Stmt is stored in a struct, which may be closed later
+		// by a different flow.
+		if _, ok := instr.Addr.(*ssa.FieldAddr); ok {
+			return actionReturned
+		}
+
 		if len(*instr.Addr.Referrers()) == 0 {
 			return actionNoOp
 		}

--- a/testdata/sqlx_examples/close_in_other_func.go
+++ b/testdata/sqlx_examples/close_in_other_func.go
@@ -1,0 +1,30 @@
+package sqlx_examples
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type Server struct {
+	Stmt *sqlx.Stmt
+}
+
+func (s *Server) Close() {
+	s.Stmt.Close()
+}
+
+func (s Server) CloseInOtherFunc() {
+	stmt, err := db.Preparex("SELECT 1")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	s.Stmt = stmt
+
+	rows := stmt.QueryRow()
+	fmt.Printf("%v", rows)
+
+	s.Close()
+}


### PR DESCRIPTION
* In attempt to avoid an alert on a Prepared Statement not closed (which is for a good reason, it is being re-used as intended), I added the logic to not alert when the target is stored in a struct.
  * This logic is not perfect. It would be better if we check the lifetime of the struct as well, or that the function itself that is storing is a struct method. I don't have much experience with analyzing SSA so if this needs some improvements, let me know.
* Changes to Makefile to allow `make test` without `go install`.