### PR TITLE
Continue to next package if it is not imported

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -95,7 +95,7 @@ func getTargetTypes(pssa *buildssa.SSA, targetPackages []string) []*types.Pointe
 		pkg := pssa.Pkg.Prog.ImportedPackage(sqlPkg)
 		if pkg == nil {
 			// the SQL package being checked isn't imported
-			return targets
+			continue
 		}
 
 		rowsType := getTypePointerFromName(pkg, rowsName)


### PR DESCRIPTION
In trying to figure out how I could add pgx to this linter (for #23), I noticed that getTargetTypes would fail to find pgx.Rows if I wasn't importing sql or sqlx.