### PR TITLE
Add support for sqlx NamedStmt

### DIFF
--- a/pgx_examples_results.txt
+++ b/pgx_examples_results.txt
@@ -1,4 +1,4 @@
 # github.com/ryanrolds/sqlclosecheck/testdata/pgx_examples
-testdata/pgx_examples/missing_close.go:8:26: Rows/Stmt was not closed
-testdata/pgx_examples/missing_close.go:17:28: Rows/Stmt was not closed
-testdata/pgx_examples/missing_close.go:26:28: Rows/Stmt was not closed
+testdata/pgx_examples/missing_close.go:8:26: Rows/Stmt/NamedStmt was not closed
+testdata/pgx_examples/missing_close.go:17:28: Rows/Stmt/NamedStmt was not closed
+testdata/pgx_examples/missing_close.go:26:28: Rows/Stmt/NamedStmt was not closed

--- a/pkg/analyzer/testdata/pgx/missing_close.go
+++ b/pkg/analyzer/testdata/pgx/missing_close.go
@@ -5,7 +5,7 @@ import (
 )
 
 func missingCloseTx() {
-	rows, err := pgxTx.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt was not closed"
+	rows, err := pgxTx.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt/NamedStmt was not closed"
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -14,7 +14,7 @@ func missingCloseTx() {
 }
 
 func missingCloseConn() {
-	rows, err := pgxConn.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt was not closed"
+	rows, err := pgxConn.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt/NamedStmt was not closed"
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func missingCloseConn() {
 }
 
 func missingClosePgxPool() {
-	rows, err := pgxPool.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt was not closed"
+	rows, err := pgxPool.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt/NamedStmt was not closed"
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/analyzer/testdata/rows/missing_close.go
+++ b/pkg/analyzer/testdata/rows/missing_close.go
@@ -7,7 +7,7 @@ import (
 
 func missingClose() {
 	age := 27
-	rows, err := db.QueryContext(ctx, "SELECT name FROM users WHERE age=?", age) // want "Rows/Stmt was not closed"
+	rows, err := db.QueryContext(ctx, "SELECT name FROM users WHERE age=?", age) // want "Rows/Stmt/NamedStmt was not closed"
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/analyzer/testdata/stmt/missing_close.go
+++ b/pkg/analyzer/testdata/stmt/missing_close.go
@@ -7,7 +7,7 @@ import (
 
 func missingClose() {
 	// In normal use, create one Stmt when your process starts.
-	stmt, err := db.PrepareContext(ctx, "SELECT username FROM users WHERE id = ?") // want "Rows/Stmt was not closed"
+	stmt, err := db.PrepareContext(ctx, "SELECT username FROM users WHERE id = ?") // want "Rows/Stmt/NamedStmt was not closed"
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/testdata/pgx_examples/expected_results.txt
+++ b/testdata/pgx_examples/expected_results.txt
@@ -1,4 +1,4 @@
 # github.com/ryanrolds/sqlclosecheck/testdata/pgx_examples
-testdata/pgx_examples/missing_close.go:8:26: Rows/Stmt was not closed
-testdata/pgx_examples/missing_close.go:17:28: Rows/Stmt was not closed
-testdata/pgx_examples/missing_close.go:26:28: Rows/Stmt was not closed
+testdata/pgx_examples/missing_close.go:8:26: Rows/Stmt/NamedStmt was not closed
+testdata/pgx_examples/missing_close.go:17:28: Rows/Stmt/NamedStmt was not closed
+testdata/pgx_examples/missing_close.go:26:28: Rows/Stmt/NamedStmt was not closed

--- a/testdata/pgx_examples/missing_close.go
+++ b/testdata/pgx_examples/missing_close.go
@@ -5,7 +5,7 @@ import (
 )
 
 func missingCloseTx() {
-	rows, err := pgxTx.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt was not closed"
+	rows, err := pgxTx.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt/NamedStmt was not closed"
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -14,7 +14,7 @@ func missingCloseTx() {
 }
 
 func missingCloseConn() {
-	rows, err := pgxConn.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt was not closed"
+	rows, err := pgxConn.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt/NamedStmt was not closed"
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func missingCloseConn() {
 }
 
 func missingClosePgxPool() {
-	rows, err := pgxPool.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt was not closed"
+	rows, err := pgxPool.Query(ctx, "SELECT username FROM users") // want "Rows/Stmt/NamedStmt was not closed"
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/testdata/sqlx_examples/expected_results.txt
+++ b/testdata/sqlx_examples/expected_results.txt
@@ -1,5 +1,6 @@
 # github.com/ryanrolds/sqlclosecheck/testdata/sqlx_examples
-testdata/sqlx_examples/failure_generics.go:6:21: Rows/Stmt was not closed
-testdata/sqlx_examples/failure_generics.go:13:21: Rows/Stmt was not closed
-testdata/sqlx_examples/missing_close.go:10:24: Rows/Stmt was not closed
+testdata/sqlx_examples/failure_generics.go:6:21: Rows/Stmt/NamedStmt was not closed
+testdata/sqlx_examples/failure_generics.go:13:21: Rows/Stmt/NamedStmt was not closed
+testdata/sqlx_examples/missing_close.go:10:24: Rows/Stmt/NamedStmt was not closed
+testdata/sqlx_examples/missing_close_named_stmt.go:8:30: Rows/Stmt/NamedStmt was not closed
 testdata/sqlx_examples/non_defer_close.go:30:12: Close should use defer

--- a/testdata/sqlx_examples/missing_close_named_stmt.go
+++ b/testdata/sqlx_examples/missing_close_named_stmt.go
@@ -1,0 +1,16 @@
+package sqlx_examples
+
+import (
+	"log"
+)
+
+func missingCloseNamedStmt() {
+	stmt, err := db.PrepareNamed("SELECT * FROM users WHERE id = :id")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// defer stmt.Close()
+
+	_ = stmt // No need to use stmt
+}


### PR DESCRIPTION
Additionally to Stmt and Rows, sqlx exposes [NamedStmt](https://pkg.go.dev/github.com/jmoiron/sqlx#NamedStmt)
As for Stmt, they should also be closed to avoid pool exhaustion and potential leaks