### PR TITLE
Add support for deferred closer functions which are not methods

### DIFF
--- a/pkg/analyzer/defer_only.go
+++ b/pkg/analyzer/defer_only.go
@@ -247,6 +247,15 @@ func getAction(instr ssa.Instruction, targetTypes []any) action {
 			if name == closeMethod {
 				return actionClosed
 			}
+		} else if instr.Call.Value != nil {
+			// If it is a deferred function, go further down the call chain
+			if f, ok := instr.Call.Value.(*ssa.Function); ok {
+				for _, b := range f.Blocks {
+					if checkClosed(&b.Instrs, targetTypes) {
+						return actionHandled
+					}
+				}
+			}
 		}
 
 		return actionUnvaluedDefer

--- a/testdata/sqlx_examples/close_in_other_func.go
+++ b/testdata/sqlx_examples/close_in_other_func.go
@@ -15,7 +15,7 @@ func (s *Server) Close() {
 	s.Stmt.Close()
 }
 
-func (s Server) CloseInOtherFunc() {
+func (s Server) CloseInOtherMethod() {
 	stmt, err := db.Preparex("SELECT 1")
 	if err != nil {
 		log.Fatal(err)
@@ -27,4 +27,21 @@ func (s Server) CloseInOtherFunc() {
 	fmt.Printf("%v", rows)
 
 	s.Close()
+}
+
+func CloseSqlxStmt(stmt *sqlx.Stmt) {
+	if stmt != nil {
+		stmt.Close()
+	}
+}
+
+func (s Server) DeferCloseInOtherFunc() {
+	stmt, err := db.Preparex("SELECT 1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer CloseSqlxStmt(stmt)
+
+	rows := stmt.QueryRow()
+	fmt.Printf("%v", rows)
 }


### PR DESCRIPTION
As it has been outlined in #7 - some people need to do some checks whenever they close some statements. If these closer functions are deferred, sqlclosecheck marks the rows as not closed. The current PR fixes that mistake. Test included.

I have also renamed a test that was checking a method, but was actually named like it would have been checking a function.