### PR TITLE
(cont) Add support for deferred closer functions which are not methods

### DIFF
--- a/pkg/analyzer/defer_only.go
+++ b/pkg/analyzer/defer_only.go
@@ -332,7 +332,27 @@ func getAction(instr ssa.Instruction, targetTypes []any) action {
 			return actionHandled
 		}
 	case *ssa.Return:
-		return actionReturned
+		if len(instr.Results) != 0 {
+			for _, result := range instr.Results {
+				resultType := result.Type()
+				for _, targetType := range targetTypes {
+					var tt types.Type
+
+					switch t := targetType.(type) {
+					case *types.Pointer:
+						tt = t
+					case *types.Named:
+						tt = t
+					default:
+						continue
+					}
+
+					if types.Identical(resultType, tt) {
+						return actionReturned
+					}
+				}
+			}
+		}
 	}
 
 	return actionUnhandled

--- a/testdata/sqlx_examples/expected_results.txt
+++ b/testdata/sqlx_examples/expected_results.txt
@@ -2,5 +2,6 @@
 testdata/sqlx_examples/failure_generics.go:6:21: Rows/Stmt/NamedStmt was not closed
 testdata/sqlx_examples/failure_generics.go:13:21: Rows/Stmt/NamedStmt was not closed
 testdata/sqlx_examples/missing_close.go:10:24: Rows/Stmt/NamedStmt was not closed
+testdata/sqlx_examples/missing_close_in_other_func.go:17:26: Rows/Stmt/NamedStmt was not closed
 testdata/sqlx_examples/missing_close_named_stmt.go:8:30: Rows/Stmt/NamedStmt was not closed
 testdata/sqlx_examples/non_defer_close.go:30:12: Close should use defer

--- a/testdata/sqlx_examples/missing_close_in_other_func.go
+++ b/testdata/sqlx_examples/missing_close_in_other_func.go
@@ -1,0 +1,25 @@
+package sqlx_examples
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func ForgetCloseSqlxStmt(stmt *sqlx.Stmt) {
+	if stmt != nil {
+		// stmt.Close()
+	}
+}
+
+func (s Server) DeferForgetCloseInOtherFunc() {
+	stmt, err := db.Preparex("SELECT 1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ForgetCloseSqlxStmt(stmt)
+
+	rows := stmt.QueryRow()
+	fmt.Printf("%v", rows)
+}


### PR DESCRIPTION
This is a fix PR relating to #33 - empty return functions would be assumed to prime handling the closing of rows statements. This is obviously only true if the return instruction's results include one of the relevant types.

As a result, deferred functions which do not close the initial statement would pass without a linter error. I have added a test to verify this case outputs an error.

This probably completes the issue #7 