### PR TITLE
fix: Referrers() may return nil

### DIFF
--- a/pkg/analyzer/defer_only.go
+++ b/pkg/analyzer/defer_only.go
@@ -292,6 +292,10 @@ func getAction(instr ssa.Instruction, targetTypes []any) action {
 			return actionReturned
 		}
 
+		if instr.Addr.Referrers() == nil {
+			return actionNoOp
+		}
+
 		if len(*instr.Addr.Referrers()) == 0 {
 			return actionNoOp
 		}
@@ -378,6 +382,10 @@ func checkDeferred(pass *analysis.Pass, instrs *[]ssa.Instruction, targetTypes [
 				return
 			}
 		case *ssa.Store:
+			if instr.Addr.Referrers() == nil {
+				return
+			}
+
 			if len(*instr.Addr.Referrers()) == 0 {
 				return
 			}


### PR DESCRIPTION
When I running golangci-lint with the sqlclosecheck@v0.5.1 a runtime panic occurs due to a nil pointer dereference because ssa.Value.Referrers() may return nil.

This fix only adds defensive checks. I run the tests (make test) and test results diffs show no differences.